### PR TITLE
Change how the Custom Statatistic is registerd

### DIFF
--- a/src/main/java/com/integral/enigmaticlegacy/EnigmaticLegacy.java
+++ b/src/main/java/com/integral/enigmaticlegacy/EnigmaticLegacy.java
@@ -755,7 +755,7 @@ public class EnigmaticLegacy {
 
 	private ResourceLocation makeCustomStat(String pKey, StatFormatter pFormatter) {
 		ResourceLocation resourcelocation = new ResourceLocation(EnigmaticLegacy.MODID, pKey);
-		Registry.register(Registry.CUSTOM_STAT, pKey, resourcelocation);
+		Registry.register(Registry.CUSTOM_STAT, resourcelocation, resourcelocation);
 		Stats.CUSTOM.get(resourcelocation, pFormatter);
 		return resourcelocation;
 	}


### PR DESCRIPTION
This fix's issues with Magma Foundation and it still works on normal forge just fine this makes it so it does no register under minecraft and will register under the mod ID