### PR TITLE
Add Bumblezone Bee Queen to Cursed Ring's blacklist

### DIFF
--- a/src/main/java/com/aizistral/enigmaticlegacy/items/CursedRing.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/items/CursedRing.java
@@ -180,7 +180,7 @@ public class CursedRing extends ItemBaseCurio {
 
 			// Ugly but gets the job done
 			neutralAngerBlacklist.clear();
-			String[] blacklist = builder.config.getStringList("CursedRingNeutralAngerBlacklist", "The Seven Curses", new String[0], "List of entities that should never be affected"
+			String[] blacklist = builder.config.getStringList("CursedRingNeutralAngerBlacklist", "The Seven Curses", new String[]{ "the_bumblezone:bee_queen" }, "List of entities that should never be affected"
 					+ " by the Second Curse of Ring of the Seven Curses. Examples: minecraft:iron_golem, minecraft:zombified_piglin. Changing this option required game restart to take effect.");
 
 			Arrays.stream(blacklist).forEach(entry -> neutralAngerBlacklist.add(new ResourceLocation(entry)));

--- a/src/main/java/com/aizistral/enigmaticlegacy/items/CursedRing.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/items/CursedRing.java
@@ -180,7 +180,11 @@ public class CursedRing extends ItemBaseCurio {
 
 			// Ugly but gets the job done
 			neutralAngerBlacklist.clear();
-			String[] blacklist = builder.config.getStringList("CursedRingNeutralAngerBlacklist", "The Seven Curses", new String[]{ "the_bumblezone:bee_queen" }, "List of entities that should never be affected"
+
+			// See https://github.com/Aizistral-Studios/Enigmatic-Legacy/pull/412
+			neutralAngerBlacklist.add(new ResourceLocation("the_bumblezone", "bee_queen"));
+
+			String[] blacklist = builder.config.getStringList("CursedRingNeutralAngerBlacklist", "The Seven Curses", new String[0], "List of entities that should never be affected"
 					+ " by the Second Curse of Ring of the Seven Curses. Examples: minecraft:iron_golem, minecraft:zombified_piglin. Changing this option required game restart to take effect.");
 
 			Arrays.stream(blacklist).forEach(entry -> neutralAngerBlacklist.add(new ResourceLocation(entry)));


### PR DESCRIPTION
Basically a short summary from what I said on Discord, I am the developer of Bumblezone and a large portion of the progression in my mod is locked behind trading with the Bee Queen.

However, the queen will not trade when angry and she is a Neutral Mob. This means players stuck with the Cursed Ring cannot trade with the Bee Queen and is locked out of a large portion of my mod and come to me asking why my mod is broken.

Having the Bee Queen be a default entry in the blacklist will help minimize confusion in modpacks with both of our mods on and help keep my mod playable.

I was not able to test this change in dev because Gradle complains about needing some sort of Curio dependency. But the provided ResourceLocation for the Bee Queen is correct.