### PR TITLE
Enchanter Pearl - Apotheosis compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,50 +72,31 @@ dependencies {
     annotationProcessor 'org.ow2.asm:asm-tree:7.2'
     annotationProcessor 'org.ow2.asm:asm-commons:7.2'
     annotationProcessor 'org.ow2.asm:asm-util:7.2'
-	
-	// These are 1.19 dependencies
-	compileOnly fg.deobf('generic:curios:forge-1.19.2-5.1.1.0')
-	compileOnly fg.deobf('generic:Patchouli:1.19.2-77')
-	compileOnly fg.deobf('generic:WorldNameRandomizer:FORGE-1.19.2-v1.5.0')
-	compileOnly fg.deobf('generic:caelus:forge-1.19.2-3.0.0.6')
-	compileOnly fg.deobf('generic:jei:1.18.2-forge-10.2.1.283-stripped')
-	
-	// These are 1.18 dependencies
-	//compileOnly fg.deobf('generic:curios:forge-1.18.2-5.0.6.3')
-	//compileOnly fg.deobf('generic:Patchouli:1.18.2-71.1')
-	//compileOnly fg.deobf('generic:WorldNameRandomizer:FORGE-1.18.1-v1.3.0')
-	//compileOnly fg.deobf('generic:caelus:forge-1.18.1-3.0.0.2')
-	//compileOnly fg.deobf('generic:jei:1.18.2-9.7.0.193')
-	//compileOnly fg.deobf('generic:Quark:3.2-346')
-	//compileOnly fg.deobf('generic:AutoRegLib:1.7-53')
-	
-	// These are 1.17 dependencies
-	//compileOnly fg.deobf('generic:curios:forge-1.17.1-5.0.2.7-spec')
-	//compileOnly fg.deobf('generic:Patchouli:1.17.1-57')
-	//compileOnly fg.deobf('generic:WorldNameRandomizer:FORGE-1.17.1-v1.2.0')
-	
-	// These are 1.16.3 - 1.16.5 dependencies
-	//implementation name: 'BuildResourceUpdater-1.0-deobf'
-	//implementation name: 'curios-forge-1.16.5-4.0.6.8-dev'
-	//implementation name: 'Patchouli-1.16.4-53.2-dev'
-	//implementation name: 'WorldNameRandomizer-FORGE-1.16.4-v1.1.1-dev'
-	//implementation name: 'decorativeblocks-1.16.1-1.5.2-deobf'
-	//implementation name: 'playerex-1.1.8-1.16.5-dev'
-	
-	//compile fg.deobf('generic:Survive:1.16.3-3.0.2')
-	//compile fg.deobf('generic:EnchantmentDescriptions:1.16.4-6.0.1')
-    //compile fg.deobf("generic:Apotheosis:1.16.3-4.4.1")
-    //compile fg.deobf("generic:Placebo:1.16.3-4.3.3")
-	
-	// These are 1.16.2 dependencies
-	//compile fg.deobf('top.theillusivec4.curios:curios-forge:1.16.2-4.0.0.1')
-    //compile fg.deobf("vazkii.patchouli:Patchouli:1.16-41")
-	
-	// These are 1.16.1 dependencies
-	//compile fg.deobf('generic:decorativeblocks:1.16.1-1.4')
-	//compile fg.deobf('top.theillusivec4.curios:curios:FORGE-1.16.1-3.0.0.2')
-    //compile fg.deobf("vazkii.patchouli:Patchouli:1.16-39")
 
+    // implementation to run it locally
+
+    // # --- JEI --- #
+    implementation fg.deobf("mezz.jei:jei-${version_mc}-forge:${version_jei}")
+    implementation fg.deobf("mezz.jei:jei-${version_mc}-common-api:${version_jei}")
+
+    // # --- Curios --- #
+    implementation fg.deobf("top.theillusivec4.curios:curios-forge:${version_mc}-${version_curios}")
+    implementation fg.deobf("top.theillusivec4.curios:curios-forge:${version_mc}-${version_curios}:api")
+
+    // # --- Patchouli --- #
+    implementation fg.deobf("vazkii.patchouli:Patchouli:${version_mc}-${version_patchouli}")
+    implementation fg.deobf("vazkii.patchouli:Patchouli:${version_mc}-${version_patchouli}:api")
+
+    // # --- Caelus API --- #
+    implementation fg.deobf("top.theillusivec4.caelus:caelus-forge:${version_mc}-${version_caelus}")
+
+    // TODO :: Is this needed?
+    implementation fg.deobf("curse.maven:world-name-randomizer-348277:4074642") // 1.19.2 - 1.5.0
+
+    // # --- Apotheosis & dependencies --- #
+    implementation fg.deobf('curse.maven:apotheosis-313970:4547399') // 1.19.2 - 6.2.1
+    // Only needed to run it locally
+    implementation fg.deobf("curse.maven:placebo-283644:4546960") // 1.19.2 - 7.2.0
 }
 
 tasks.withType(Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
 		maven { url "file:///${project.projectDir}/deps/" }
-        maven { url = 'https://files.minecraftforge.net/maven' }
+        maven { url = 'https://maven.minecraftforge.net' }
         maven {
             name "Sponge"
             url "https://repo.spongepowered.org/repository/maven-public/"
@@ -23,7 +23,7 @@ buildscript {
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
 		classpath 'gradle.plugin.com.matthewprenger:CurseGradle:1.4.0'
-        classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-1.0.0-SNAPSHOT'
+        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
 		classpath 'org.parchmentmc:librarian:1.+'
     }
 }
@@ -55,6 +55,7 @@ mixin {
 	println("Specifying refmaps for Mixin...")
 	
     add sourceSets.main, "enigmaticlegacy.refmap.json"
+    config "enigmaticlegacy.mixins.json"
 }
 
 minecraft {
@@ -66,7 +67,7 @@ dependencies {
 	println("Processing dependencies...")
    
 	// Mixin
-    annotationProcessor 'org.spongepowered:mixin:0.8.4:processor'
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
     annotationProcessor 'com.google.code.gson:gson:2.8.0'
     annotationProcessor 'com.google.guava:guava:21.0'
     annotationProcessor 'org.ow2.asm:asm-tree:7.2'
@@ -97,14 +98,6 @@ dependencies {
     implementation fg.deobf('curse.maven:apotheosis-313970:4547399') // 1.19.2 - 6.2.1
     // Only needed to run it locally
     implementation fg.deobf("curse.maven:placebo-283644:4546960") // 1.19.2 - 7.2.0
-}
-
-tasks.withType(Jar) {
-    manifest {
-        attributes([
-            "MixinConnector": "${project.group}.MixinConnector"
-        ])
-    }
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -93,11 +93,6 @@ dependencies {
 
     // TODO :: Is this needed?
     implementation fg.deobf("curse.maven:world-name-randomizer-348277:4074642") // 1.19.2 - 1.5.0
-
-    // # --- Apotheosis & dependencies --- #
-    implementation fg.deobf('curse.maven:apotheosis-313970:4547399') // 1.19.2 - 6.2.1
-    // Only needed to run it locally
-    implementation fg.deobf("curse.maven:placebo-283644:4546960") // 1.19.2 - 7.2.0
 }
 
 processResources {

--- a/common.gradle
+++ b/common.gradle
@@ -56,14 +56,12 @@ sourceSets.main.resources {
 repositories {
 	println("Specifying repositories...")
 	
-	
-	//flatDir {  dirs 'deps' }
-	maven {  url "file:///${project.projectDir}/deps/" } // I'LL FUCKING STAB YOUR PARENTS
-	maven {  url = "https://maven.theillusivec4.top/" } // curios
-	maven {  url 'https://maven.blamejared.com' } // patchouli
-	maven {  url = "https://repo.spongepowered.org/maven" } // mixin
-    maven {	 url "https://dvs1.progwml6.com/files/maven/" } // no idea
-	maven {  url = 'https://maven.parchmentmc.org'  }
+    maven { url 'https://maven.blamejared.com' } // JEI & more
+	maven { url = "https://maven.theillusivec4.top/" } // Curios
+    maven { url "https://cursemaven.com" } // CurseForge
+	maven { url = "https://repo.spongepowered.org/maven" } // Mixin
+	maven { url = 'https://maven.parchmentmc.org' } // Parchment
+//	maven {  url "file:///${project.projectDir}/deps/" } // I'LL FUCKING STAB YOUR PARENTS
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ mod_icon=EL_logo.png
 mod_license=Enigmatic Legacy License
 
 # Dependency specifications for mods.toml
-dep_forge=[43.1.0,)
+dep_forge=[43.2.0,)
 dep_minecraft=[1.19,1.20)
 dep_curios=[1.19.2-5.1.1.0,)
 dep_patchouli=[1.19.2-77,)
@@ -31,8 +31,12 @@ dep_caelus=[1.19.2-3.0.0.6,)
 
 # Dependencies specifications for build.gradle
 version_mc=1.19.2
-version_forge=1.19.2-43.1.47
+version_forge=1.19.2-43.2.0
 version_mcp=2022.11.06-1.19.2
+version_curios=5.1.3.0
+version_jei=11.6.0.1016
+version_patchouli=77
+version_caelus=3.0.0.6
 
 # CurseGradle
 curse_id=336184

--- a/src/main/java/com/aizistral/enigmaticlegacy/mixin/ApplyMixinPlugin.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/mixin/ApplyMixinPlugin.java
@@ -1,0 +1,45 @@
+package com.aizistral.enigmaticlegacy.mixin;
+
+import net.minecraftforge.fml.loading.LoadingModList;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class ApplyMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(final String mixinPackage) { /* Nothing to do */ }
+
+    @Override
+    public String getRefMapperConfig() {
+        /* Nothing to do */
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(final String targetClassName, final String mixinClassName) {
+        // `ModList.get()` is not available at this point in time
+        if (mixinClassName.equals("com.aizistral.enigmaticlegacy.mixin.apotheosis.MixinApothEnchantContainer")) {
+            return LoadingModList.get().getModFileById("apotheosis") != null;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(final Set<String> myTargets, final Set<String> otherTargets) { /* Nothing to do */ }
+
+    @Override
+    public List<String> getMixins() {
+        /* Nothing to do */
+        return null;
+    }
+
+    @Override
+    public void preApply(final String targetClassName, final ClassNode targetClass, final String mixinClassName, final IMixinInfo mixinInfo) { /* Nothing to do */ }
+
+    @Override
+    public void postApply(final String targetClassName, final ClassNode targetClass, final String mixinClassName, final IMixinInfo mixinInfo) { /* Nothing to do */ }
+}

--- a/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
@@ -40,12 +40,20 @@ public abstract class MixinApothEnchantContainer {
     /** {@link net.minecraft.world.Container#setItem(int, ItemStack)} seems to clear all information (enchantment stats, costs, etc.) from the instance - that's why we get the list of enchantments while that information is still available */
     @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V", shift = At.Shift.BEFORE, ordinal = 1))
     public void prepareDoubleRoll(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
-        enigmaticLegacy$copyBeforeEnchanted = toEnchant.copy();
+        if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
+            enigmaticLegacy$copyBeforeEnchanted = toEnchant.copy();
 
-        // TODO :: Add config to not use a new seed for the double roll?
-        ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
-        container.enchantmentSeed.set(container.random.nextInt());
-        enigmaticLegacy$storedEnchantmentList = getEnchantmentList(enigmaticLegacy$copyBeforeEnchanted, id, level);
+            ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
+            int storedValue = container.enchantmentSeed.get();
+
+            container.enchantmentSeed.set(container.random.nextInt());
+            enigmaticLegacy$storedEnchantmentList = getEnchantmentList(enigmaticLegacy$copyBeforeEnchanted, id, level);
+            /*
+            Not sure if this is needed (gets overwritten by `player.getEnchantmentSeed()` shortly afterward anyway
+            (List of enchantments has already been collected (using the same seed as the list of clues) at this point)
+            */
+            container.enchantmentSeed.set(storedValue);
+        }
     }
 
     /** Handle the double enchanting effect */

--- a/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
@@ -18,12 +18,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import shadows.apotheosis.Apoth;
 import shadows.apotheosis.ench.asm.EnchHooks;
 import shadows.apotheosis.ench.table.ApothEnchantContainer;
 import shadows.apotheosis.ench.table.IEnchantableItem;
-import shadows.apotheosis.ench.table.RealEnchantmentHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -32,48 +30,37 @@ import java.util.Map;
  * Priority is set higher to run after other modifications (e.g. changes to the result of getEnchantmentList)<br>
  * (<a href="https://github.com/Daripher/Passive-Skill-Tree">Example Mod</a>)
  */
-@Mixin(value = ApothEnchantContainer.class, priority = 1500, remap = false)
-public class MixinApothEnchantContainer {
+@Mixin(value = ApothEnchantContainer.class, priority = 1500)
+public abstract class MixinApothEnchantContainer {
     @Unique private ItemStack enigmaticLegacy$copyBeforeEnchanted;
     @Unique private List<EnchantmentInstance> enigmaticLegacy$storedEnchantmentList;
 
-    @Shadow private List<EnchantmentInstance> getEnchantmentList(ItemStack stack, int enchantSlot, int level) { return null; }
+    @Shadow(remap = false) private List<EnchantmentInstance> getEnchantmentList(ItemStack stack, int enchantSlot, int level) { return null; }
 
-
-    @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "HEAD"))
-    public void storeBeforeEnchant(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
+    /** `this.enchantSlots.setItem(...)` seems to clear all information (enchantment stats, costs, etc.) from the instance - that's why we get the list of enchantments why that information is still available */
+    @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V", shift = At.Shift.BEFORE, ordinal = 1))
+    public void prepareDoubleRoll(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
         enigmaticLegacy$copyBeforeEnchanted = toEnchant.copy();
-    }
 
-    @ModifyVariable(method = "lambda$clickMenuButton$0", at = @At(value = "STORE"), name = "list")
-    public List<EnchantmentInstance> storeListOfEnchants(final List<EnchantmentInstance> list) {
-        // FIXME :: Currently only used to check if its a fusion enchant - can probably be removed
-        enigmaticLegacy$storedEnchantmentList = list;
-        return list;
+        // TODO :: Add config to not use a new seed for the double roll?
+        ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
+        container.enchantmentSeed.set(container.random.nextInt());
+        enigmaticLegacy$storedEnchantmentList = getEnchantmentList(enigmaticLegacy$copyBeforeEnchanted, id, level);
     }
 
     /** Handle the double enchanting effect */
-    @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", shift = At.Shift.BEFORE), remap = true, locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-    public void handleEnchanterPearl(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci, /* Locals: */ final ItemStack itemStack, float eterna, float quanta, float arcana, float rectification) {
+    @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", shift = At.Shift.BEFORE))
+    public void handleEnchanterPearl(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
         if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
-            if (enigmaticLegacy$storedEnchantmentList.get(0).enchantment == Apoth.Enchantments.INFUSION.get()) {
+            if (enigmaticLegacy$storedEnchantmentList == null || enigmaticLegacy$storedEnchantmentList.get(0).enchantment == Apoth.Enchantments.INFUSION.get()) {
                 // Ignore Infusion enchants
                 return;
             }
 
-            /* FIXME
-            The levels (enchantment stats, costs etc.) for this object are only set on LocalPlayer but not ServerPlayer (and we are working with ServerPlayer here)
-            That's why we cannot just use container.getEnchantmentList(...)`
-            */
-            ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
-
-            // Setting a new seed here using `container.enchantmentSeed.get()` causes it to be identical to the previous seed
-            List<EnchantmentInstance> list = RealEnchantmentHelper.selectEnchantment(
-                    container.random, enigmaticLegacy$copyBeforeEnchanted, level, quanta, arcana, rectification, false
-            );
-
             // Use Apotheosis enchantment method
-            enigmaticLegacy$copyBeforeEnchanted = ((IEnchantableItem) enigmaticLegacy$copyBeforeEnchanted.getItem()).onEnchantment(enigmaticLegacy$copyBeforeEnchanted, list);
+            enigmaticLegacy$copyBeforeEnchanted = ((IEnchantableItem) enigmaticLegacy$copyBeforeEnchanted.getItem()).onEnchantment(enigmaticLegacy$copyBeforeEnchanted, enigmaticLegacy$storedEnchantmentList);
+
+            ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
 
             /*
             The enchantment result gets directly set in the `enchantSlots` not in the ItemStack
@@ -91,8 +78,8 @@ public class MixinApothEnchantContainer {
      * Enchanter Pearl disables lapis cost<br>
      * The "There are no possible signatures for this injector" error is not accurate<br>
      */
-    @ModifyVariable(method = "clickMenuButton", at = @At(value = "STORE"), name = "lapis", remap = true)
-    public ItemStack fakeLapis(final ItemStack lapis, /* Method parameter: */ final Player player) {
+    @ModifyVariable(method = "clickMenuButton", at = @At(value = "STORE"), name = "lapis")
+    public ItemStack fakeLapis(final ItemStack lapis, /* Method arguments: */ final Player player) {
         // Store reference to client container?
         if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
             ItemStack fakeLapis = Items.LAPIS_LAZULI.getDefaultInstance();

--- a/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
@@ -37,7 +37,7 @@ public abstract class MixinApothEnchantContainer {
 
     @Shadow(remap = false) private List<EnchantmentInstance> getEnchantmentList(ItemStack stack, int enchantSlot, int level) { return null; }
 
-    /** `this.enchantSlots.setItem(...)` seems to clear all information (enchantment stats, costs, etc.) from the instance - that's why we get the list of enchantments why that information is still available */
+    /** {@link net.minecraft.world.Container#setItem(int, ItemStack)} seems to clear all information (enchantment stats, costs, etc.) from the instance - that's why we get the list of enchantments while that information is still available */
     @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V", shift = At.Shift.BEFORE, ordinal = 1))
     public void prepareDoubleRoll(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
         enigmaticLegacy$copyBeforeEnchanted = toEnchant.copy();
@@ -90,7 +90,7 @@ public abstract class MixinApothEnchantContainer {
         return lapis;
     }
 
-    /** Copied from {@link SuperpositionHandler#mergeEnchantments} to use {@link EnchHooks}, seemed simpler than handling class loading etc. */
+    /** Copied from {@link SuperpositionHandler#mergeEnchantments(ItemStack, ItemStack, boolean, boolean)} to use {@link EnchHooks}, seemed simpler than handling class loading etc. */
     @Unique
     private ItemStack enigmaticLegacy$mergeEnchantments(final ItemStack input, final ItemStack mergeFrom, boolean overmerge, boolean onlyTreasure) {
         ItemStack returnedStack = input.copy();

--- a/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
@@ -1,0 +1,148 @@
+package com.aizistral.enigmaticlegacy.mixin.apotheosis;
+
+import com.aizistral.enigmaticlegacy.handlers.SuperpositionHandler;
+import com.aizistral.enigmaticlegacy.registries.EnigmaticItems;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.stats.Stats;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.EnchantmentMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.EnchantmentInstance;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import shadows.apotheosis.Apoth;
+import shadows.apotheosis.advancements.EnchantedTrigger;
+import shadows.apotheosis.ench.table.ApothEnchantContainer;
+import shadows.apotheosis.ench.table.EnchantingRecipe;
+import shadows.apotheosis.ench.table.IEnchantableItem;
+import shadows.apotheosis.util.FloatReferenceHolder;
+
+import java.util.List;
+
+@Mixin(ApothEnchantContainer.class)
+public class MixinApothEnchantContainer extends EnchantmentMenu {
+    public MixinApothEnchantContainer(int containerID, final Inventory playerInventory) {
+        super(containerID, playerInventory);
+    }
+
+    @Shadow @Final protected FloatReferenceHolder eterna;
+    @Shadow @Final protected FloatReferenceHolder quanta;
+    @Shadow @Final protected FloatReferenceHolder arcana;
+    @Shadow @Final protected FloatReferenceHolder rectification;
+
+    /**
+     * Copied Original method (1.19.2 - 6.2.1)
+     */
+    @Override
+    public boolean clickMenuButton(Player player, int id) {
+        // New :: START
+        boolean hasPearl = EnigmaticItems.ENCHANTER_PEARL.isPresent(player);
+        // New :: END
+
+        int level = this.costs[id];
+        ItemStack preFinalItem = this.enchantSlots.getItem(0);
+        // New :: Need to do this so that the field is considered final
+        ItemStack lapis = hasPearl ? Items.LAPIS_LAZULI.getDefaultInstance() : this.getSlot(1).getItem();
+
+        // New :: START
+        if (hasPearl) {
+            lapis.setCount(64);
+        }
+        // New :: END
+
+        int cost = id + 1;
+        if ((lapis.isEmpty() || lapis.getCount() < cost) && !player.getAbilities().instabuild) {
+            return false;
+        } else if (this.costs[id] > 0
+                && !preFinalItem.isEmpty()
+                && (player.experienceLevel >= cost && player.experienceLevel >= this.costs[id] || player.getAbilities().instabuild)) {
+            this.access
+                    .execute(
+                            (world, pos) -> {
+                                // New :: `preFinalItem` was previously `toEnchant` - need to do this to re-assign later for the merge
+                                ItemStack toEnchant = preFinalItem;
+
+                                float eterna = this.eterna.get();
+                                float quanta = this.quanta.get();
+                                float arcana = this.arcana.get();
+                                float rectification = this.rectification.get();
+                                List<EnchantmentInstance> list = this.getEnchantmentList(toEnchant, id, this.costs[id]);
+                                if (!list.isEmpty()) {
+                                    // New :: START
+                                    ItemStack doubleRoll = ItemStack.EMPTY;
+
+                                    if (hasPearl) {
+                                        // Doing this here to work with a clean un-enchanted item
+                                        doubleRoll = EnchantmentHelper.enchantItem(player.getRandom(), toEnchant.copy(), Math.min(costs[id] + 7, 40), true);
+                                    }
+                                    // New :: END
+
+                                    player.onEnchantmentPerformed(toEnchant, cost);
+                                    if (((EnchantmentInstance)list.get(0)).enchantment == Apoth.Enchantments.INFUSION.get()) {
+                                        EnchantingRecipe match = EnchantingRecipe.findMatch(world, toEnchant, eterna, quanta, arcana);
+                                        if (match == null) {
+                                            return;
+                                        }
+
+                                        this.enchantSlots.setItem(0, match.assemble(toEnchant, eterna, quanta, arcana));
+                                    } else {
+                                        this.enchantSlots.setItem(0, ((IEnchantableItem)toEnchant.getItem()).onEnchantment(toEnchant, list));
+                                    }
+
+                                    if (!player.getAbilities().instabuild) {
+                                        lapis.shrink(cost);
+                                        if (lapis.isEmpty()) {
+                                            this.enchantSlots.setItem(1, ItemStack.EMPTY);
+                                        }
+                                    }
+
+                                    // New :: START
+                                    if (hasPearl) {
+                                        toEnchant = SuperpositionHandler.mergeEnchantments(toEnchant, doubleRoll, false, false);
+                                        toEnchant = SuperpositionHandler.maybeApplyEternalBinding(toEnchant);
+
+                                        enchantSlots.setItem(0, toEnchant);
+                                    }
+                                    // New :: END
+
+                                    player.awardStat(Stats.ENCHANT_ITEM);
+                                    if (player instanceof ServerPlayer) {
+                                        ((EnchantedTrigger) CriteriaTriggers.ENCHANTED_ITEM)
+                                                .trigger((ServerPlayer)player, toEnchant, level, eterna, quanta, arcana, rectification);
+                                    }
+
+                                    this.enchantSlots.setChanged();
+                                    this.enchantmentSeed.set(player.getEnchantmentSeed());
+                                    this.slotsChanged(this.enchantSlots);
+                                    world.playSound(
+                                            (Player)null, pos, SoundEvents.ENCHANTMENT_TABLE_USE, SoundSource.BLOCKS, 1.0F, world.random.nextFloat() * 0.1F + 0.9F
+                                    );
+                                }
+                            }
+                    );
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // TODO :: Keeping this around in case there is a way to avoid overriding the entire method
+//    /** Enchanter Pearl disables lapis cost (Ignore the "There are no possible signatures for this injector") */
+//    @ModifyVariable(method = "clickMenuButton", at = @At(value = "STORE"), name = "lapis", remap = false)
+//    public ItemStack fakeLapis(final ItemStack lapis, /* Method arguments: */ final Player player) {
+//        if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
+//            ItemStack dummy = Items.LAPIS_LAZULI.getDefaultInstance();
+//            dummy.setCount(64);
+//            return dummy;
+//        }
+//
+//        return lapis;
+//    }
+}

--- a/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/mixin/apotheosis/MixinApothEnchantContainer.java
@@ -1,9 +1,12 @@
 package com.aizistral.enigmaticlegacy.mixin.apotheosis;
 
+import com.aizistral.enigmaticlegacy.EnigmaticLegacy;
 import com.aizistral.enigmaticlegacy.handlers.SuperpositionHandler;
 import com.aizistral.enigmaticlegacy.registries.EnigmaticItems;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.EnchantmentMenu;
 import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -11,84 +14,96 @@ import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import shadows.apotheosis.Apoth;
-import shadows.apotheosis.ench.asm.EnchHooks;
-import shadows.apotheosis.ench.table.ApothEnchantContainer;
-import shadows.apotheosis.ench.table.IEnchantableItem;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Priority is set higher to run after other modifications (e.g. changes to the result of getEnchantmentList)<br>
- * (<a href="https://github.com/Daripher/Passive-Skill-Tree">Example Mod</a>)
- */
-@Mixin(value = ApothEnchantContainer.class, priority = 1500)
-public abstract class MixinApothEnchantContainer {
-    @Unique private ItemStack enigmaticLegacy$copyBeforeEnchanted;
-    @Unique private List<EnchantmentInstance> enigmaticLegacy$storedEnchantmentList;
+@Pseudo
+@Mixin(targets = "shadows.apotheosis.ench.table.ApothEnchantContainer", priority = 1500) // Probably not needed anymore
+public abstract class MixinApothEnchantContainer extends EnchantmentMenu {
+    @Unique
+    private ItemStack enigmaticLegacy$copyBeforeEnchanted;
+    @Unique
+    private List<EnchantmentInstance> enigmaticLegacy$storedEnchantmentList;
 
-    @Shadow(remap = false) private List<EnchantmentInstance> getEnchantmentList(ItemStack stack, int enchantSlot, int level) { return null; }
+    @Unique
+    private Method enigmaticLegacy$onEnchantment;
+    @Unique
+    private Method enigmaticLegacy$getMaxLevel;
+    @Unique
+    private Method enigmaticLegacy$isTreasureOnly;
 
-    /** {@link net.minecraft.world.Container#setItem(int, ItemStack)} seems to clear all information (enchantment stats, costs, etc.) from the instance - that's why we get the list of enchantments while that information is still available */
+    public MixinApothEnchantContainer(int containerID, final Inventory playerInventory) {
+        super(containerID, playerInventory);
+    }
+
+    /**
+     * {@link net.minecraft.world.Container#setItem(int, ItemStack)} seems to clear all information (enchantment stats, costs, etc.) from the instance - that's why we get the list of enchantments while that information is still available
+     */
     @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V", shift = At.Shift.BEFORE, ordinal = 1))
     public void prepareDoubleRoll(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
         if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
             enigmaticLegacy$copyBeforeEnchanted = toEnchant.copy();
 
-            ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
-            int storedValue = container.enchantmentSeed.get();
+            int storedValue = enchantmentSeed.get();
 
-            container.enchantmentSeed.set(container.random.nextInt());
+            enchantmentSeed.set(random.nextInt());
             enigmaticLegacy$storedEnchantmentList = getEnchantmentList(enigmaticLegacy$copyBeforeEnchanted, id, level);
             /*
             Not sure if this is needed (gets overwritten by `player.getEnchantmentSeed()` shortly afterward anyway
             (List of enchantments has already been collected (using the same seed as the list of clues) at this point)
             */
-            container.enchantmentSeed.set(storedValue);
-        }
-    }
-
-    /** Handle the double enchanting effect */
-    @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", shift = At.Shift.BEFORE))
-    public void handleEnchanterPearl(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
-        if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
-            if (enigmaticLegacy$storedEnchantmentList == null || enigmaticLegacy$storedEnchantmentList.get(0).enchantment == Apoth.Enchantments.INFUSION.get()) {
-                // Ignore Infusion enchants
-                return;
-            }
-
-            // Use Apotheosis enchantment method
-            enigmaticLegacy$copyBeforeEnchanted = ((IEnchantableItem) enigmaticLegacy$copyBeforeEnchanted.getItem()).onEnchantment(enigmaticLegacy$copyBeforeEnchanted, enigmaticLegacy$storedEnchantmentList);
-
-            ApothEnchantContainer container = (ApothEnchantContainer) (Object) this;
-
-            /*
-            The enchantment result gets directly set in the `enchantSlots` not in the ItemStack
-            If the modifications are done using `toEnchant` then it will cause enchanted books to be reverted back to being tomes (if they previously were tomes) when merging
-            */
-            ItemStack enchantedItem = container.enchantSlots.getItem(0);
-            enchantedItem = enigmaticLegacy$mergeEnchantments(enchantedItem, enigmaticLegacy$copyBeforeEnchanted, false, false);
-            enchantedItem = SuperpositionHandler.maybeApplyEternalBinding(enchantedItem);
-
-            container.enchantSlots.setItem(0, enchantedItem);
+            enchantmentSeed.set(storedValue);
         }
     }
 
     /**
-     * Enchanter Pearl disables lapis cost<br>
-     * The "There are no possible signatures for this injector" error is not accurate<br>
+     * Handle the double enchanting effect
      */
-    @ModifyVariable(method = "clickMenuButton", at = @At(value = "STORE"), name = "lapis")
-    public ItemStack fakeLapis(final ItemStack lapis, /* Method arguments: */ final Player player) {
-        // Store reference to client container?
+    @Inject(method = "lambda$clickMenuButton$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;awardStat(Lnet/minecraft/resources/ResourceLocation;)V", shift = At.Shift.BEFORE))
+    public void handleEnchanterPearl(final ItemStack toEnchant, int id, final Player player, int cost, final ItemStack lapis, int level, final Level world, final BlockPos pos, final CallbackInfo ci) {
+        if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
+            if (enigmaticLegacy$storedEnchantmentList == null || enigmaticLegacy$storedEnchantmentList.get(0).enchantment.getClass().getSimpleName().equals("InertEnchantment")) {
+                // Ignore Infusion enchants
+                return;
+            }
+
+            enigmaticLegacy$initMethods();
+
+            try {
+                // Use Apotheosis enchantment method
+                enigmaticLegacy$copyBeforeEnchanted = (ItemStack) enigmaticLegacy$onEnchantment.invoke(enigmaticLegacy$copyBeforeEnchanted.getItem(), enigmaticLegacy$copyBeforeEnchanted, enigmaticLegacy$storedEnchantmentList);
+
+                /*
+                The enchantment result gets directly set in the `enchantSlots` not in the ItemStack
+                If the modifications are done using `toEnchant` then it will cause enchanted books to be reverted back to being tomes (if they previously were tomes) when merging
+                */
+                ItemStack enchantedItem = enchantSlots.getItem(0);
+                enchantedItem = enigmaticLegacy$mergeEnchantments(enchantedItem, enigmaticLegacy$copyBeforeEnchanted, false, false);
+                enchantedItem = SuperpositionHandler.maybeApplyEternalBinding(enchantedItem);
+
+                enchantSlots.setItem(0, enchantedItem);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                EnigmaticLegacy.LOGGER.error("Could not invoke `onEnchantment` for [" + enigmaticLegacy$copyBeforeEnchanted.getDisplayName() + "]", e);
+            }
+        }
+    }
+
+    /**
+     * Without explicitly naming the class path here it will crash due to not finding a proper injection point
+     */
+    @ModifyVariable(method = "shadows.apotheosis.ench.table.ApothEnchantContainer.clickMenuButton(Lnet/minecraft/world/entity/player/Player;I)Z", at = @At(value = "STORE"), name = "lapis")
+    public ItemStack fakeLapis(final ItemStack lapis, /* Method parameters: */ final Player player) {
         if (EnigmaticItems.ENCHANTER_PEARL.isPresent(player)) {
             ItemStack fakeLapis = Items.LAPIS_LAZULI.getDefaultInstance();
             fakeLapis.setCount(64);
@@ -98,25 +113,27 @@ public abstract class MixinApothEnchantContainer {
         return lapis;
     }
 
-    /** Copied from {@link SuperpositionHandler#mergeEnchantments(ItemStack, ItemStack, boolean, boolean)} to use {@link EnchHooks}, seemed simpler than handling class loading etc. */
+    /**
+     * Copied from {@link SuperpositionHandler#mergeEnchantments(ItemStack, ItemStack, boolean, boolean)} to use {@link EnchHooks}, seemed simpler than handling class loading etc.
+     */
     @Unique
-    private ItemStack enigmaticLegacy$mergeEnchantments(final ItemStack input, final ItemStack mergeFrom, boolean overmerge, boolean onlyTreasure) {
+    private ItemStack enigmaticLegacy$mergeEnchantments(final ItemStack input, final ItemStack mergeFrom, boolean overmerge, boolean onlyTreasure) throws InvocationTargetException, IllegalAccessException {
         ItemStack returnedStack = input.copy();
         Map<Enchantment, Integer> inputEnchants = EnchantmentHelper.getEnchantments(returnedStack);
         Map<Enchantment, Integer> mergedEnchants = EnchantmentHelper.getEnchantments(mergeFrom);
 
-        for(Enchantment mergedEnchant : mergedEnchants.keySet()) {
+        for (Enchantment mergedEnchant : mergedEnchants.keySet()) {
             if (mergedEnchant != null) {
                 int inputEnchantLevel = inputEnchants.getOrDefault(mergedEnchant, 0);
                 int mergedEnchantLevel = mergedEnchants.get(mergedEnchant);
 
                 if (!overmerge) {
                     // +1 when the levels match, otherwise pick the higher one
-                    mergedEnchantLevel = inputEnchantLevel == mergedEnchantLevel ? Math.min(mergedEnchantLevel + 1, EnchHooks.getMaxLevel(mergedEnchant)) : Math.max(mergedEnchantLevel, inputEnchantLevel);
+                    mergedEnchantLevel = inputEnchantLevel == mergedEnchantLevel ? Math.min(mergedEnchantLevel + 1, (Integer) enigmaticLegacy$getMaxLevel.invoke(mergedEnchant)) : Math.max(mergedEnchantLevel, inputEnchantLevel);
                 } else {
                     // Always add +1 if both items have the enchantment
                     mergedEnchantLevel = inputEnchantLevel > 0 ? Math.max(mergedEnchantLevel, inputEnchantLevel) + 1 : Math.max(mergedEnchantLevel, inputEnchantLevel);
-                    mergedEnchantLevel = Math.min(mergedEnchantLevel, EnchHooks.getMaxLevel(mergedEnchant));
+                    mergedEnchantLevel = Math.min(mergedEnchantLevel, (Integer) enigmaticLegacy$getMaxLevel.invoke(mergedEnchant));
                 }
 
                 boolean compatible = mergedEnchant.canEnchant(input);
@@ -124,14 +141,14 @@ public abstract class MixinApothEnchantContainer {
                     compatible = true;
                 }
 
-                for(Enchantment originalEnchant : inputEnchants.keySet()) {
+                for (Enchantment originalEnchant : inputEnchants.keySet()) {
                     if (originalEnchant != mergedEnchant && !mergedEnchant.isCompatibleWith(originalEnchant)) {
                         compatible = false;
                     }
                 }
 
                 if (compatible) {
-                    if (!onlyTreasure || EnchHooks.isTreasureOnly(mergedEnchant) || mergedEnchant.isCurse()) {
+                    if (!onlyTreasure || (Boolean) enigmaticLegacy$isTreasureOnly.invoke(mergedEnchant) || mergedEnchant.isCurse()) {
                         inputEnchants.put(mergedEnchant, mergedEnchantLevel);
                     }
                 }
@@ -140,5 +157,27 @@ public abstract class MixinApothEnchantContainer {
 
         EnchantmentHelper.setEnchantments(inputEnchants, returnedStack);
         return returnedStack;
+    }
+
+    /**
+     * Method call to avoid <a href="https://github.com/SpongePowered/Mixin/issues/322">Cannot handle AASTORE opcode (0x53)</a>
+     */
+    @Unique
+    private void enigmaticLegacy$initMethods() {
+        if (enigmaticLegacy$onEnchantment == null || enigmaticLegacy$getMaxLevel == null || enigmaticLegacy$isTreasureOnly == null) {
+            try {
+                Class<?> enchantableItem = Class.forName("shadows.apotheosis.ench.table.IEnchantableItem");
+                enigmaticLegacy$onEnchantment = ObfuscationReflectionHelper.findMethod(enchantableItem, "onEnchantment", ItemStack.class, List.class);
+
+                Class<?> enchHooks = Class.forName("shadows.apotheosis.ench.asm.EnchHooks");
+                enigmaticLegacy$getMaxLevel = ObfuscationReflectionHelper.findMethod(enchHooks, "getMaxLevel", Enchantment.class);
+                enigmaticLegacy$isTreasureOnly = ObfuscationReflectionHelper.findMethod(enchHooks, "isTreasureOnly", Enchantment.class);
+            } catch (ClassNotFoundException e) {
+                EnigmaticLegacy.LOGGER.error("Could not initialize `EnchHooks` methods", e);
+
+                enigmaticLegacy$getMaxLevel = ObfuscationReflectionHelper.findMethod(Enchantment.class, "m_6586_");
+                enigmaticLegacy$isTreasureOnly = ObfuscationReflectionHelper.findMethod(Enchantment.class, "m_6591_");
+            }
+        }
     }
 }

--- a/src/main/java/com/aizistral/enigmaticlegacy/objects/LoggerWrapper.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/objects/LoggerWrapper.java
@@ -46,6 +46,10 @@ public class LoggerWrapper {
 		this.logger.error(this.markError, line);
 	}
 
+	public void error(String line, Exception e) {
+		this.logger.error(this.markError, line, e);
+	}
+
 	public void catching(Throwable ex) {
 		this.logger.catching(ex);
 	}

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-MixinConnector: com.aizistral.enigmaticlegacy.MixinConnector

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -65,3 +65,5 @@ public net.minecraft.world.entity.ai.goal.target.TargetGoal f_26135_ #mob
 public net.minecraft.world.entity.ai.goal.target.TargetGoal f_26137_ #targetMob
 public net.minecraft.server.MinecraftServer f_129762_ #levels
 public net.minecraft.world.level.storage.LevelSummary
+
+public net.minecraft.world.inventory.EnchantmentMenu f_39451_ # random

--- a/src/main/resources/enigmaticlegacy.mixins.json
+++ b/src/main/resources/enigmaticlegacy.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "package": "com.aizistral.enigmaticlegacy.mixin",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "com.aizistral.enigmaticlegacy.mixin.ApplyMixinPlugin",
   "refmap": "enigmaticlegacy.refmap.json",
   "verbose": true,
   "mixins": [
@@ -30,7 +31,8 @@
 	"MixinEnterBlockTrigger",
 	"MixinItemStack",
 	"MixinPlayerList",
-	"MixinCrossbowItem"
+	"MixinCrossbowItem",
+    "apotheosis.MixinApothEnchantContainer"
   ],
   "client": [
 	"AccessorDisconnectedScreen",

--- a/src/main/resources/enigmaticlegacy.mixins.json
+++ b/src/main/resources/enigmaticlegacy.mixins.json
@@ -5,7 +5,6 @@
   "compatibilityLevel": "JAVA_17",
   "plugin": "com.aizistral.enigmaticlegacy.mixin.ApplyMixinPlugin",
   "refmap": "enigmaticlegacy.refmap.json",
-  "verbose": true,
   "mixins": [
 	"MixinPiglinTasks",
 	"MixinVillagerEntity",


### PR DESCRIPTION
Tested it in a larger modpack, worked fine (but you never know I guess)
Only tries to apply the Mixin if Apotheosis is present

Currently it sets a new seed to get a new list of enchantments for the double roll
(and restores the previous seed afterward)

---

* Uses the maximum levels of Apotheosis as limit
* Uses Apotheosis configuration to check if it's a treasure enchant or not
* Uses Apotheosis enchantment method
* Should have support for other mods which e.g. modify the result of Apotheosis enchantment method
