### PR TITLE
1.19.X/Improve flying scrolls performance

### DIFF
--- a/src/main/java/com/aizistral/enigmaticlegacy/items/FabulousScroll.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/items/FabulousScroll.java
@@ -49,7 +49,7 @@ public class FabulousScroll extends HeavenScroll {
 
 	@Override
 	public void curioTick(SlotContext context, ItemStack stack) {
-		if (context.entity().level.isClientSide)
+		if (context.entity().level().isClientSide)
 			return;
 
 		if (context.entity() instanceof Player player) {
@@ -63,7 +63,7 @@ public class FabulousScroll extends HeavenScroll {
 			final int fabConsumptionProbMod = 8;
 			//only check xp drain if flying.
 			//because we're only checking once per 20 ticks, increase the probability by 20
-			if (shouldCheckXpDrain(player) && !inRange && Math.random() <= ((this.baseXpConsumptionProbability * fabConsumptionProbMod) * 20)) {
+			if (this.shouldCheckXpDrain(player) && !inRange && Math.random() <= ((this.baseXpConsumptionProbability * fabConsumptionProbMod) * 20)) {
 				//cost modifier hooked up to drain xp cost
 				ExperienceHelper.drainPlayerXP(player, (int) (xpCostModifier.getValue()));
 			}

--- a/src/main/java/com/aizistral/enigmaticlegacy/items/HeavenScroll.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/items/HeavenScroll.java
@@ -111,7 +111,8 @@ public class HeavenScroll extends ItemBaseCurio {
 				player.getAbilities().mayfly = true;
 				//since we're only updating once per 20 ticks, we can leave this here as we won't be spamming update packets
 				player.onUpdateAbilities();
-				this.flyMap.put(player, 100);
+				//reduced from 100 down to 5, as we now only run this code once per second.
+				this.flyMap.put(player, 5);
 
 			} else if (this.flyMap.get(player) > 1) {
 				this.flyMap.put(player, this.flyMap.get(player)-1);

--- a/src/main/java/com/aizistral/enigmaticlegacy/items/HeavenScroll.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/items/HeavenScroll.java
@@ -83,12 +83,12 @@ public class HeavenScroll extends ItemBaseCurio {
 
 	@Override
 	public void curioTick(SlotContext context, ItemStack stack) {
-		if (context.entity().level.isClientSide)
+		if (context.entity().level().isClientSide)
 			return;
 
 		if (context.entity() instanceof Player player) {
 			//since we don't need to check if in range of beacon here, we can run this xp check every frame.
-			if (shouldCheckXpDrain(player) && Math.random() <= this.baseXpConsumptionProbability) {
+			if (this.shouldCheckXpDrain(player) && Math.random() <= this.baseXpConsumptionProbability) {
 				//hook into xp cost modifier from config.
 				ExperienceHelper.drainPlayerXP(player, (int) xpCostModifier.getValue());
 			}
@@ -107,7 +107,7 @@ public class HeavenScroll extends ItemBaseCurio {
 			return;
 
 		try {
-			if (canFly(player, inRangeCheckedAndSucceeded)) {
+			if (this.canFly(player, inRangeCheckedAndSucceeded)) {
 				player.getAbilities().mayfly = true;
 				//since we're only updating once per 20 ticks, we can leave this here as we won't be spamming update packets
 				player.onUpdateAbilities();


### PR DESCRIPTION
👋  Heya. Just a pull request improving the performance of the flying scrolls. Because block scanning is expensive, the function checking if there's a beacon nearby was drastically slowing down our server. Especially when multiple people were using their scrolls at the same time.

I've offloaded these checks to happen once per second, depending on the player's tick count. Fabulous scroll was also checking if it was in range of a beacon twice in the same function, so cleaned that up too. 

To account for fabulous scroll only checking in range once per 20 ticks instead of per single tick, the probability of xp consumption was increased by 20. 