### PR TITLE
fix issue #545

### DIFF
--- a/src/main/java/com/aizistral/etherium/core/EtheriumEventHandler.java
+++ b/src/main/java/com/aizistral/etherium/core/EtheriumEventHandler.java
@@ -42,9 +42,8 @@ public class EtheriumEventHandler {
 			 */
 
 			if (EtheriumArmor.hasShield(player)) {
-				if (event.getSource().getDirectEntity() instanceof LivingEntity) {
-					LivingEntity attacker = ((LivingEntity) event.getSource().getEntity());
-					Vector3 vec = Vector3.fromEntityCenter(player).subtract(Vector3.fromEntityCenter(event.getSource().getEntity())).normalize();
+				if (event.getSource().getDirectEntity() instanceof LivingEntity attacker) {
+					Vector3 vec = Vector3.fromEntityCenter(player).subtract(Vector3.fromEntityCenter(attacker)).normalize();
 					attacker.knockback(0.75F, vec.x, vec.z);
 					player.level().playSound(null, player.blockPosition(), this.config.getShieldTriggerSound(), SoundSource.PLAYERS, 1.0F, 0.9F + (float) (Math.random() * 0.1D));
 					player.level().playSound(null, player.blockPosition(), this.config.getShieldTriggerSound(), SoundSource.PLAYERS, 1.0F, 0.9F + (float) (Math.random() * 0.1D));


### PR DESCRIPTION
by issue #545, etherium armor knockback causes game crash, as the mod tests if `direct_entity` is a `LivingEntity`, then knocks back the `source_entity`, which is null, thus causes NPE
fixed by knocking back the `direct_entity` instead of the `source_entity`