### PR TITLE
Fix: 1.19.X unholy stone bug

### DIFF
--- a/src/main/java/com/aizistral/enigmaticlegacy/registries/EnigmaticItems.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/registries/EnigmaticItems.java
@@ -324,7 +324,7 @@ public class EnigmaticItems extends AbstractRegistry<Item> {
 	public static final GoldenRing GOLDEN_RING = null;
 
 	@ConfigurableItem("Unholy Stone")
-	@ObjectHolder(value = MODID + ":unholy_stone", registryName = "item")
+	@ObjectHolder(value = MODID + ":cursed_stone", registryName = "item")
 	public static final CursedStone CURSED_STONE = null;
 
 	@ConfigurableItem("Enchanter's Pearl")


### PR DESCRIPTION
Due to this, unholy stone is not registered properly. Therefore, dying does not detect it and it won't remove the Cursed Ring

p.s. if you want the Jar already built, refer to https://github.com/andresmarpz/Enigmatic-Legacy/actions/runs/18078462133/artifacts/4126575228