### PR TITLE
Handle client-side crash?

### DIFF
--- a/src/main/java/com/aizistral/enigmaticlegacy/helpers/ItemNBTHelper.java
+++ b/src/main/java/com/aizistral/enigmaticlegacy/helpers/ItemNBTHelper.java
@@ -28,7 +28,8 @@ public final class ItemNBTHelper {
 
 	public static CompoundTag getNBT(final ItemStack stack) {
 		ItemNBTHelper.initNBT(stack);
-		return stack.getTag();
+		var tag = stack.getTag();
+		return tag == null ? new CompoundTag() : tag;
 	}
 
 	public static void setBoolean(final ItemStack stack, final String tag, final boolean b) {


### PR DESCRIPTION
So we have this rare but weird client-side crash - https://gnomebot.dev/paste/mclogs/KVehx17

I managed to handle the crash with mixin, but have no idea what's the correct solution from EL, sorry - https://github.com/SaloEater/Enigmatic-Legacy-Crash-Handler/blob/main/src/main/java/com/author/blank_mixin_mod/mixin/ItemNBTHelperMixin.java#L38
And here is the log of an item that produces that NPE:
```
  Item     : etherium_core
  Count    : 1
  isEmpty  : false
  Serialized: {Count:1b,id:"enigmaticaddons:etherium_core"}
  ```

Feel free to request any changes related to this matter, because, obviously, returning new Tag for server-side is a bummer yet I doubt that ever happens, only client-side